### PR TITLE
refactor: address clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#[forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
@@ -43,7 +43,7 @@ fn with_raw<F: AsFd, R>(mut fd: F, f: impl FnOnce(&mut F) -> R) -> R {
     }
     let r = f(&mut fd);
     if let Ok(ref orig_attrs) = orig_attrs {
-        termios::tcsetattr(fd.as_fd(), termios::OptionalActions::Now, &orig_attrs)
+        termios::tcsetattr(fd.as_fd(), termios::OptionalActions::Now, orig_attrs)
             .expect("could not set terminal attributes");
     }
     r
@@ -442,7 +442,7 @@ where
                 &alacritty_terminal::tty::Options {
                     shell: Some(alacritty_terminal::tty::Shell::new(
                         command,
-                        cli.args.unwrap_or(vec![]),
+                        cli.args.unwrap_or_default(),
                     )),
                     working_directory: None,
                     hold: false,
@@ -455,8 +455,8 @@ where
                     },
                 },
                 alacritty_terminal::event::WindowSize {
-                    num_lines: lines.into(),
-                    num_cols: columns.into(),
+                    num_lines: lines,
+                    num_cols: columns,
                     cell_width: 1,
                     cell_height: 1,
                 },

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -4,8 +4,8 @@ use rustix::event::{poll as rustix_poll, PollFd};
 /// Block until any of the [PollFd]s is satisfied. Returns an array with the [PollFd]s that had
 /// events (the result array's order is equal to the input order). If any [PollFd] is [None], it is
 /// ignored and its result is `false`.
-pub fn poll<'fd, const C: usize>(
-    mut poll_fds: [Option<PollFd<'fd>>; C],
+pub fn poll<const C: usize>(
+    mut poll_fds: [Option<PollFd<'_>>; C],
     timeout: Option<std::time::Duration>,
 ) -> std::io::Result<[bool; C]> {
     let mut polls = ArrayVec::<_, C>::new();

--- a/termsnap-lib/src/colors.rs
+++ b/termsnap-lib/src/colors.rs
@@ -128,13 +128,8 @@ pub(crate) fn most_common_color(screen: &Screen) -> Rgb {
         }
     }
 
+    #[derive(Default)]
     struct NoHashHasher(u64);
-
-    impl Default for NoHashHasher {
-        fn default() -> Self {
-            NoHashHasher(0)
-        }
-    }
 
     impl Hasher for NoHashHasher {
         fn finish(&self) -> u64 {

--- a/termsnap-lib/src/lib.rs
+++ b/termsnap-lib/src/lib.rs
@@ -23,7 +23,7 @@
 //! println!("{}", screen.to_svg(&[]));
 //! ```
 
-#[forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 use std::fmt::{Display, Write};
 
 use alacritty_terminal::{


### PR DESCRIPTION
addressed warnings:
```rust
warning: useless lint attribute
  --> termsnap-lib/src/lib.rs:26:1
   |
26 | #[forbid(unsafe_code)]
   | ^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![forbid(unsafe_code)]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_attribute

warning: this `impl` can be derived
   --> termsnap-lib/src/colors.rs:133:5
    |
133 | /     impl Default for NoHashHasher {
134 | |         fn default() -> Self {
135 | |             NoHashHasher(0)
136 | |         }
137 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls
    = note: `-W clippy::derivable-impls` implied by `-W clippy::complexity`
    = help: to override `-W clippy::complexity` add `#[allow(clippy::derivable_impls)]`
    = help: remove the manual implementation...
help: ...and instead derive it
    |
131 +     #[derive(Default)]
132 |     struct NoHashHasher(u64);
    |

warning: useless lint attribute
 --> src/main.rs:1:1
  |
1 | #[forbid(unsafe_code)]
  | ^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![forbid(unsafe_code)]`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_attribute

warning: the following explicit lifetimes could be elided: 'fd
 --> src/poll.rs:7:13
  |
7 | pub fn poll<'fd, const C: usize>(
  |             ^^^
8 |     mut poll_fds: [Option<PollFd<'fd>>; C],
  |                                  ^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
  = note: `-W clippy::needless-lifetimes` implied by `-W clippy::complexity`
  = help: to override `-W clippy::complexity` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
  |
7 ~ pub fn poll<const C: usize>(
8 ~     mut poll_fds: [Option<PollFd<'_>>; C],
  |

warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/main.rs:46:71
   |
46 |         termios::tcsetattr(fd.as_fd(), termios::OptionalActions::Now, &orig_attrs)
   |                                                                       ^^^^^^^^^^^ help: change this to: `orig_attrs`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: use of `unwrap_or` to construct default value
   --> src/main.rs:445:34
    |
445 |                         cli.args.unwrap_or(vec![]),
    |                                  ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_default

warning: useless conversion to the same type: `u16`
   --> src/main.rs:458:32
    |
458 |                     num_lines: lines.into(),
    |                                ^^^^^^^^^^^^ help: consider removing `.into()`: `lines`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: useless conversion to the same type: `u16`
   --> src/main.rs:459:31
    |
459 |                     num_cols: columns.into(),
    |                               ^^^^^^^^^^^^^^ help: consider removing `.into()`: `columns`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
```